### PR TITLE
fix: S3 Store incorrectly marshalling Client IDs

### DIFF
--- a/client-id/store/s3.go
+++ b/client-id/store/s3.go
@@ -92,6 +92,7 @@ func (s *s3Store) reloadCache(ctx context.Context) error {
 
 	for identifier, cid := range s.cache {
 		cid.Identifier = identifier
+		s.cache[identifier] = cid
 	}
 
 	s.lastETag = response.ETag

--- a/client-id/store/s3.go
+++ b/client-id/store/s3.go
@@ -31,7 +31,7 @@ type s3Store struct {
 	Bucket string
 	Key    string
 
-	cacheMutex sync.RWMutex
+	cacheMutex *sync.RWMutex
 	lastReload time.Time
 	lastETag   *string
 	cache      models.ClientIDs
@@ -55,9 +55,10 @@ func NewS3Store(cp client.ConfigProvider, arn arn.ARN) Store {
 	}
 
 	return &s3Store{
-		Client: s3.New(cp, aws.NewConfig().WithRegion(arn.Region)),
-		Bucket: bucket,
-		Key:    key,
+		Client:     s3.New(cp, aws.NewConfig().WithRegion(arn.Region)),
+		Bucket:     bucket,
+		Key:        key,
+		cacheMutex: new(sync.RWMutex),
 	}
 }
 

--- a/client-id/store/s3.go
+++ b/client-id/store/s3.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"gopkg.in/yaml.v3"
@@ -25,7 +26,7 @@ const (
 )
 
 type s3Store struct {
-	Client *s3.S3
+	Client s3Client
 
 	Bucket string
 	Key    string
@@ -34,6 +35,10 @@ type s3Store struct {
 	lastReload time.Time
 	lastETag   *string
 	cache      models.ClientIDs
+}
+
+type s3Client interface {
+	GetObjectWithContext(context.Context, *s3.GetObjectInput, ...request.Option) (*s3.GetObjectOutput, error)
 }
 
 func NewS3Store(cp client.ConfigProvider, arn arn.ARN) Store {

--- a/client-id/store/s3_test.go
+++ b/client-id/store/s3_test.go
@@ -59,6 +59,7 @@ func TestS3GetClientID_Happy(t *testing.T) {
 		Client:     client,
 		Bucket:     expectedBucket,
 		Key:        expectedKey,
+		cacheMutex: new(sync.RWMutex),
 	}
 
 	cid, err := store.GetClientID(ctx, string(expectedIdentifier))

--- a/client-id/store/s3_test.go
+++ b/client-id/store/s3_test.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/SKF/go-utility/v2/uuid"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"gopkg.in/yaml.v3"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SKF/go-enlight-middleware/client-id/models"
+)
+
+type clientMock struct {
+	mock.Mock
+}
+
+func (mock *clientMock) GetObjectWithContext(ctx context.Context, inp *s3.GetObjectInput, opt ...request.Option) (*s3.GetObjectOutput, error) {
+	args := mock.Called(ctx, inp, opt)
+	return args.Get(0).(*s3.GetObjectOutput), args.Error(1)
+}
+
+func TestS3GetClientID_Happy(t *testing.T) {
+	var (
+		expectedBucket     = "bucket"
+		expectedKey        = "key"
+		expectedIdentifier = uuid.UUID("2bf8888d-c379-415d-b532-b829400964f6")
+	)
+
+	b := new(bytes.Buffer)
+
+	ids := models.ClientIDs{
+		expectedIdentifier: {
+			Name: "Test 1",
+		},
+	}
+
+	err := yaml.NewEncoder(b).Encode(ids)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client := new(clientMock)
+	expectedInput := mock.MatchedBy(func(i *s3.GetObjectInput) bool {
+		return *i.Bucket == expectedBucket && *i.Key == expectedKey
+	})
+
+	client.On("GetObjectWithContext", ctx, expectedInput, mock.Anything).Return(&s3.GetObjectOutput{
+		Body: io.NopCloser(b),
+	}, nil).Once()
+
+	store := s3Store{
+		Client:     client,
+		Bucket:     expectedBucket,
+		Key:        expectedKey,
+	}
+
+	cid, err := store.GetClientID(ctx, string(expectedIdentifier))
+	require.NoError(t, err)
+
+	require.Equal(t, expectedIdentifier, cid.Identifier)
+	require.Equal(t, ids[expectedIdentifier].Name, cid.Name)
+
+	client.AssertExpectations(t)
+}


### PR DESCRIPTION
This caused the Client ID middleware to incorrectly allow clients marked in the S3 file as disabled/expired to use the API (if the API marked Client IDs as required).