### PR TITLE
Handle context deadline exceeded

### DIFF
--- a/authorization/handler.go
+++ b/authorization/handler.go
@@ -71,7 +71,10 @@ func (m *Middleware) Middleware() func(http.Handler) http.Handler {
 				}
 
 				if err := policy.Authorize(ctx, userID, m.authorizerClient, r); err != nil {
-					problems.WriteResponse(ctx, err, w, r)
+					if !errors.Is(err, context.Canceled) {
+						problems.WriteResponse(ctx, err, w, r)
+					}
+
 					span.End()
 					return
 				}


### PR DESCRIPTION
Returns a context.DeadlineExceeded error when the response status code is DeadlineExceeded.

Skips writing a response body when Authorize returns a context.Canceled error, as there's no point writing a response if the client cancels the request.