### PR TITLE
cache has been removed, go-utility has been upgraded

### DIFF
--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/gorilla/mux"
 	old_errors "github.com/pkg/errors"
@@ -36,7 +35,6 @@ type Middleware struct {
 	Tracer         middleware.Tracer
 
 	unauthenticatedRoutes []*mux.Route
-	userIDCache           *sync.Map // map[jwt.Subject]EnlightUserID
 }
 
 func New(opts ...Option) *Middleware {
@@ -49,7 +47,6 @@ func New(opts ...Option) *Middleware {
 		Tracer:         new(middleware.OpenCensusTracer),
 
 		unauthenticatedRoutes: []*mux.Route{},
-		userIDCache:           new(sync.Map),
 	}
 
 	for _, opt := range opts {

--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -37,7 +37,6 @@ type Middleware struct {
 
 	unauthenticatedRoutes []*mux.Route
 	userIDCache           *sync.Map // map[jwt.Subject]EnlightUserID
-	ssoClient             *SSOClient
 }
 
 func New(opts ...Option) *Middleware {
@@ -51,7 +50,6 @@ func New(opts ...Option) *Middleware {
 
 		unauthenticatedRoutes: []*mux.Route{},
 		userIDCache:           new(sync.Map),
-		ssoClient:             NewSSOClient(defaultStage),
 	}
 
 	for _, opt := range opts {

--- a/authentication/options.go
+++ b/authentication/options.go
@@ -7,7 +7,5 @@ type Option func(*Middleware)
 func WithStage(stage string) Option {
 	return func(m *Middleware) {
 		jwk.Configure(jwk.Config{Stage: stage})
-
-		m.ssoClient = NewSSOClient(stage)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/SKF/go-enlight-sdk/v2 v2.13.0
 	github.com/SKF/go-rest-utility v0.10.1
-	github.com/SKF/go-utility/v2 v2.27.0
+	github.com/SKF/go-utility/v2 v2.29.0
 	github.com/SKF/proto/v2 v2.18.0-go
 	github.com/aws/aws-sdk-go v1.43.33
 	github.com/golang-jwt/jwt/v4 v4.4.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,11 @@ github.com/SKF/go-enlight-sdk/v2 v2.13.0 h1:N2dbIZoOrmeV/eVaqXKmRLVvreIkwf1GfvPL
 github.com/SKF/go-enlight-sdk/v2 v2.13.0/go.mod h1:vaJCPigIkGFLupnqN7CTjflR57mFZykVbxhHlhgHefY=
 github.com/SKF/go-rest-utility v0.10.1 h1:DG0YRdHCFDraxbcLNn6m2bTnk18r1cOH5LLgi0WKeEk=
 github.com/SKF/go-rest-utility v0.10.1/go.mod h1:k5+4TrtQFUTenRsbxgLu/KhOkaaLaoblaS93JLy0Q30=
+github.com/SKF/go-utility v1.10.4 h1:/ANSV7G7cRgnjdrdMhsSY7Z5eoJibSihMBO0YQDS1ag=
 github.com/SKF/go-utility/v2 v2.27.0 h1:NsedFbIY/1Jrf1pbj11MQlLmIahdjKRmAFMf84T8EBY=
 github.com/SKF/go-utility/v2 v2.27.0/go.mod h1:uHFUYZL5p9HYstelDwQBuKV1NzzKS6i5xlV8l2BlFmc=
+github.com/SKF/go-utility/v2 v2.29.0 h1:qB0oitZTwEql9ndFojF4rQP9k7d53O6Pss7Laf0DiO0=
+github.com/SKF/go-utility/v2 v2.29.0/go.mod h1:Nd3wuNk43YqfIYrOlxkwYjaEZwHMoOGm89cKk/ntnfU=
 github.com/SKF/proto/v2 v2.18.0-go h1:ki2dwT3EcbP6Nh9T8j+k3xb9r9QSx/f4Ja7Otj/7m8Y=
 github.com/SKF/proto/v2 v2.18.0-go/go.mod h1:z77J6TRSzNE3jRFoRLi4blPQN1Esow82d2k+f+x14Qg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=


### PR DESCRIPTION
Tokens have been restructured to put impersonator and enlight user id in it. So we don't need to identify user's Enlight id by querying SSO service anymore.