### PR TITLE
Add HSTS middleware

### DIFF
--- a/hsts/handler.go
+++ b/hsts/handler.go
@@ -1,0 +1,87 @@
+package hsts
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	middleware "github.com/SKF/go-enlight-middleware"
+)
+
+const (
+	Header        string        = "Strict-Transport-Security"
+	DefaultMaxAge time.Duration = 365 * 24 * time.Hour
+)
+
+type Middleware struct {
+	Tracer middleware.Tracer
+
+	maxAge            time.Duration
+	includeSubDomains bool
+	preload           bool
+
+	cachedPolicy string
+}
+
+func New(opts ...Option) *Middleware {
+	m := &Middleware{
+		Tracer: new(middleware.OpenCensusTracer),
+
+		maxAge: DefaultMaxAge,
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+func (m *Middleware) Middleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, span := m.Tracer.StartSpan(r.Context(), "Middleware/HSTS")
+
+			if m.isHTTPS(r) {
+				if m.cachedPolicy == "" {
+					m.cachedPolicy = m.buildPolicy()
+				}
+
+				w.Header().Add(Header, m.cachedPolicy)
+			}
+
+			span.End()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func (m *Middleware) isHTTPS(r *http.Request) bool {
+	if r.TLS != nil && r.TLS.HandshakeComplete {
+		return true
+	}
+
+	if r.Header.Get("X-Forwarded-Proto") == "https" {
+		return true
+	}
+
+	return false
+}
+
+func (m *Middleware) buildPolicy() string {
+	policy := new(strings.Builder)
+
+	policy.WriteString("max-age=")
+	policy.WriteString(strconv.Itoa(int(m.maxAge.Seconds())))
+
+	if m.includeSubDomains {
+		policy.WriteString("; includeSubDomains")
+	}
+
+	if m.preload {
+		policy.WriteString("; preload")
+	}
+
+	return policy.String()
+}

--- a/hsts/handler_test.go
+++ b/hsts/handler_test.go
@@ -1,0 +1,106 @@
+package hsts_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/SKF/go-enlight-middleware/hsts"
+)
+
+func testHSTSMiddleware(t *testing.T, middleware *hsts.Middleware, server func(http.Handler) *httptest.Server, requestModifier func(*http.Request)) *http.Response {
+	t.Helper()
+
+	endpoint := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "OK")
+	})
+
+	srv := server(middleware.Middleware()(endpoint))
+	defer srv.Close()
+
+	r, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	if requestModifier != nil {
+		requestModifier(r)
+	}
+
+	response, err := srv.Client().Do(r)
+	require.NoError(t, err)
+
+	return response
+}
+
+func TestHTTPRequest(t *testing.T) {
+	middleware := hsts.New()
+
+	response := testHSTSMiddleware(t, middleware, httptest.NewServer, nil)
+	defer response.Body.Close()
+
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.NotContains(t, response.Header, hsts.Header)
+}
+
+func TestForwardedHTTPSRequestOverHTTP(t *testing.T) {
+	middleware := hsts.New()
+
+	response := testHSTSMiddleware(t, middleware, httptest.NewServer, func(r *http.Request) {
+		r.Header.Add("X-Forwarded-Proto", "https")
+	})
+	defer response.Body.Close()
+
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Equal(t, "max-age=31536000", response.Header.Get(hsts.Header))
+}
+
+func TestHTTPSRequest(t *testing.T) {
+	middleware := hsts.New()
+
+	response := testHSTSMiddleware(t, middleware, httptest.NewTLSServer, nil)
+	defer response.Body.Close()
+
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Equal(t, "max-age=31536000", response.Header.Get(hsts.Header))
+}
+
+func TestWithCustomMaxAge(t *testing.T) {
+	middleware := hsts.New(
+		hsts.WithMaxAge(24 * time.Hour),
+	)
+
+	response := testHSTSMiddleware(t, middleware, httptest.NewTLSServer, nil)
+	defer response.Body.Close()
+
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Equal(t, "max-age=86400", response.Header.Get(hsts.Header))
+}
+
+func TestWithIncludeSubDomains(t *testing.T) {
+	middleware := hsts.New(
+		hsts.WithMaxAge(hsts.DefaultMaxAge),
+		hsts.WithIncludeSubDomains(),
+	)
+
+	response := testHSTSMiddleware(t, middleware, httptest.NewTLSServer, nil)
+	defer response.Body.Close()
+
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Equal(t, "max-age=31536000; includeSubDomains", response.Header.Get(hsts.Header))
+}
+
+func TestWithPreload(t *testing.T) {
+	middleware := hsts.New(
+		hsts.WithMaxAge(24*time.Hour),
+		hsts.WithPreload(),
+	)
+
+	response := testHSTSMiddleware(t, middleware, httptest.NewTLSServer, nil)
+	defer response.Body.Close()
+
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Equal(t, "max-age=63072000; includeSubDomains; preload", response.Header.Get(hsts.Header))
+}

--- a/hsts/options.go
+++ b/hsts/options.go
@@ -1,0 +1,34 @@
+package hsts
+
+import "time"
+
+const (
+	oneYear  = 365 * 24 * time.Hour
+	twoYears = 2 * oneYear
+)
+
+type Option func(*Middleware)
+
+func WithMaxAge(age time.Duration) Option {
+	return func(m *Middleware) {
+		m.maxAge = age
+	}
+}
+
+func WithIncludeSubDomains() Option {
+	return func(m *Middleware) {
+		m.includeSubDomains = true
+	}
+}
+
+func WithPreload() Option {
+	return func(m *Middleware) {
+		// HSTS Preload recommendations from https://hstspreload.org/
+		if m.maxAge < oneYear {
+			m.maxAge = twoYears
+		}
+
+		m.includeSubDomains = true
+		m.preload = true
+	}
+}


### PR DESCRIPTION
A simple implementation of adding HSTS headers to requests that are using HTTPS.

The implementation supports requests forwarded through an HTTPS terminating AWS ALB.